### PR TITLE
Add missing `gl` linked library for linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ mingw :
 
 linux : OS := LINUX
 linux : CFLAGS += -DLUAVER=$(LUAVER) -D_GLFW_USE_OPENGL -D_GLFW_X11 -D_GLFW_BUILD_ALL -Iglfw/include $(shell pkg-config --cflags lua$(LUAVER)) -fPIC
-linux : LDFLAGS += $(shell pkg-config --libs lua$(LUAVER))
+linux : LDFLAGS += $(shell pkg-config --libs lua$(LUAVER) gl)
 linux :
 	# NanoVG
 	gcc -c -O3 $(CFLAGS) nanovg/src/nanovg.c


### PR DESCRIPTION
Fixes #15. In combination with #16, this makes `lua-nanovg` work on Arch Linux.