### PR TITLE
Update rockspec: Lua version 5.4 and link to GL library for Linux

### DIFF
--- a/rockspecs/nanovg-scm-1.rockspec
+++ b/rockspecs/nanovg-scm-1.rockspec
@@ -9,7 +9,7 @@ description = {
    license = "MIT"
 }
 dependencies = {
-   "lua >= 5.1, < 5.4"
+   "lua >= 5.1, <= 5.4"
 }
 build = {
    type = "builtin",
@@ -18,6 +18,13 @@ build = {
          modules = {
             nvg = {
                libraries = { "opengl32" },
+            }
+         }
+      },
+      linux = {
+         modules = {
+            nvg = {
+               libraries = { "GL" },
             }
          }
       }


### PR DESCRIPTION
Here comes an updated rockspec for Lua 5.4 and Linux. With this I was able to build lua-nanovg for Lua 5.4.4 under Windows 10 (MINGW64), MacOS 12.4 and Linux and verified this by running the [lpugl](https://github.com/osch/lua-lpugl) examples for all these platforms.